### PR TITLE
Update for Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "type": "library",
     "require": {
         "php": "^7.2",
-        "illuminate/support": "6.*",
-        "illuminate/config": "6.*",
-        "illuminate/cache": "6.*",
-        "illuminate/container": "6.*",
+        "illuminate/support": ">=5.0",
+        "illuminate/config": ">=5.0",
+        "illuminate/cache": ">=5.0",
+        "illuminate/container": ">=5.0",
         "gopay/payments-sdk-php": "^1.1"
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,11 @@
     "description": "GoPay SDK integration with Laravel Framework",
     "type": "library",
     "require": {
-        "php": ">=5.6.0",
-        "illuminate/support": "5.*",
-        "illuminate/config": "5.*",
-        "illuminate/cache": "5.*",
-        "illuminate/container": "5.*",
+        "php": "^7.2",
+        "illuminate/support": "6.*",
+        "illuminate/config": "6.*",
+        "illuminate/cache": "6.*",
+        "illuminate/container": "6.*",
         "gopay/payments-sdk-php": "^1.1"
     },
     "license": "MIT",


### PR DESCRIPTION
You cannot currently install `laravel-gopay-sdk` on Laravel 6 apps, because it requires illuminate stuff from 5.*, which can't be installed.